### PR TITLE
Windows support

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"os"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/datarhei/gosrt/internal/circular"
@@ -99,14 +98,9 @@ func Dial(network, address string, config Config) (Conn, error) {
 		return nil, fmt.Errorf("failed dialing: %w", err)
 	}
 
-	file, err := pc.File()
-	if err != nil {
-		return nil, err
-	}
-
 	// Set TOS
 	if config.IPTOS > 0 {
-		err = setSockOpt(file.Fd(), syscall.IP_TOS, config.IPTOS)
+		err = setSockOptIPTOSFromConn(pc, config.IPTOS)
 		if err != nil {
 			return nil, fmt.Errorf("failed setting socket option TOS: %w", err)
 		}
@@ -114,7 +108,7 @@ func Dial(network, address string, config Config) (Conn, error) {
 
 	// Set TTL
 	if config.IPTTL > 0 {
-		err = setSockOpt(file.Fd(), syscall.IP_TTL, config.IPTTL)
+		err = setSockOptIPTTLFromConn(pc, config.IPTTL)
 		if err != nil {
 			return nil, fmt.Errorf("failed setting socket option TTL: %w", err)
 		}

--- a/dial.go
+++ b/dial.go
@@ -106,7 +106,7 @@ func Dial(network, address string, config Config) (Conn, error) {
 
 	// Set TOS
 	if config.IPTOS > 0 {
-		err = syscall.SetsockoptInt(int(file.Fd()), syscall.IPPROTO_IP, syscall.IP_TOS, config.IPTOS)
+		err = setSockOpt(file.Fd(), syscall.IP_TOS, config.IPTOS)
 		if err != nil {
 			return nil, fmt.Errorf("failed setting socket option TOS: %w", err)
 		}
@@ -114,7 +114,7 @@ func Dial(network, address string, config Config) (Conn, error) {
 
 	// Set TTL
 	if config.IPTTL > 0 {
-		err = syscall.SetsockoptInt(int(file.Fd()), syscall.IPPROTO_IP, syscall.IP_TTL, config.IPTTL)
+		err = setSockOpt(file.Fd(), syscall.IP_TTL, config.IPTTL)
 		if err != nil {
 			return nil, fmt.Errorf("failed setting socket option TTL: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/pkg/profile v1.7.0
 	github.com/stretchr/testify v1.8.3
 	golang.org/x/crypto v0.9.0
+	golang.org/x/sys v0.8.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
 golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
+golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/listen.go
+++ b/listen.go
@@ -195,14 +195,14 @@ func Listen(network, address string, config Config) (Listener, error) {
 			var opErr error
 			err := c.Control(func(fd uintptr) {
 				// Set REUSEADDR
-				opErr = setSockOpt(fd, syscall.SO_REUSEADDR, 1)
+				opErr = setSockOptREUSE(fd)
 				if opErr != nil {
 					return
 				}
 
 				// Set TOS
 				if config.IPTOS > 0 {
-					opErr = setSockOpt(fd, syscall.IP_TOS, config.IPTOS)
+					opErr = setSockOptIPTOS(fd, config.IPTOS)
 					if opErr != nil {
 						return
 					}
@@ -210,7 +210,7 @@ func Listen(network, address string, config Config) (Listener, error) {
 
 				// Set TTL
 				if config.IPTTL > 0 {
-					opErr = setSockOpt(fd, syscall.IP_TTL, config.IPTTL)
+					opErr = setSockOptIPTTL(fd, config.IPTTL)
 					if opErr != nil {
 						return
 					}

--- a/listen.go
+++ b/listen.go
@@ -195,14 +195,14 @@ func Listen(network, address string, config Config) (Listener, error) {
 			var opErr error
 			err := c.Control(func(fd uintptr) {
 				// Set REUSEADDR
-				opErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+				opErr = setSockOpt(fd, syscall.SO_REUSEADDR, 1)
 				if opErr != nil {
 					return
 				}
 
 				// Set TOS
 				if config.IPTOS > 0 {
-					opErr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_TOS, config.IPTOS)
+					opErr = setSockOpt(fd, syscall.IP_TOS, config.IPTOS)
 					if opErr != nil {
 						return
 					}
@@ -210,7 +210,7 @@ func Listen(network, address string, config Config) (Listener, error) {
 
 				// Set TTL
 				if config.IPTTL > 0 {
-					opErr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_TTL, config.IPTTL)
+					opErr = setSockOpt(fd, syscall.IP_TTL, config.IPTTL)
 					if opErr != nil {
 						return
 					}

--- a/listen_test.go
+++ b/listen_test.go
@@ -122,7 +122,7 @@ func TestListenHSV4(t *testing.T) {
 			var opErr error
 			err := c.Control(func(fd uintptr) {
 				// Set REUSEADDR
-				opErr = setSockOpt(fd, syscall.SO_REUSEADDR, 1)
+				opErr = setSockOptREUSE(fd)
 				if opErr != nil {
 					return
 				}
@@ -269,7 +269,7 @@ func TestListenHSV5(t *testing.T) {
 			var opErr error
 			err := c.Control(func(fd uintptr) {
 				// Set REUSEADDR
-				opErr = setSockOpt(fd, syscall.SO_REUSEADDR, 1)
+				opErr = setSockOptREUSE(fd)
 				if opErr != nil {
 					return
 				}

--- a/listen_test.go
+++ b/listen_test.go
@@ -122,7 +122,7 @@ func TestListenHSV4(t *testing.T) {
 			var opErr error
 			err := c.Control(func(fd uintptr) {
 				// Set REUSEADDR
-				opErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+				opErr = setSockOpt(fd, syscall.SO_REUSEADDR, 1)
 				if opErr != nil {
 					return
 				}
@@ -269,7 +269,7 @@ func TestListenHSV5(t *testing.T) {
 			var opErr error
 			err := c.Control(func(fd uintptr) {
 				// Set REUSEADDR
-				opErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+				opErr = setSockOpt(fd, syscall.SO_REUSEADDR, 1)
 				if opErr != nil {
 					return
 				}

--- a/setsockopt.go
+++ b/setsockopt.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package srt
+
+import (
+	"syscall"
+)
+
+func setSockOpt(fd uintptr, key, value int) error {
+	return syscall.SetsockoptInt(int(fd), key, syscall.SO_REUSEADDR, value)
+}

--- a/setsockopt.go
+++ b/setsockopt.go
@@ -3,9 +3,36 @@
 package srt
 
 import (
+	"net"
 	"syscall"
 )
 
-func setSockOpt(fd uintptr, key, value int) error {
-	return syscall.SetsockoptInt(int(fd), key, syscall.SO_REUSEADDR, value)
+func setSockOptREUSE(fd uintptr) error {
+	return syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+}
+
+func setSockOptIPTOS(fd uintptr, tos int) error {
+	return syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_TOS, tos)
+}
+
+func setSockOptIPTTL(fd uintptr, ttl int) error {
+	return syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_TTL, ttl)
+}
+
+func setSockOptIPTOSFromConn(c *net.UDPConn, tos int) error {
+	file, err := c.File()
+	if err != nil {
+		return err
+	}
+	fd := file.Fd()
+	return setSockOptIPTOS(fd, tos)
+}
+
+func setSockOptIPTTLFromConn(c *net.UDPConn, ttl int) error {
+	file, err := c.File()
+	if err != nil {
+		return err
+	}
+	fd := file.Fd()
+	return setSockOptIPTTL(fd, ttl)
 }

--- a/setsockopt_windows.go
+++ b/setsockopt_windows.go
@@ -3,10 +3,31 @@
 package srt
 
 import (
+	"fmt"
+	"net"
+	"os"
+
 	"golang.org/x/sys/windows"
-	"syscall"
 )
 
-func setSockOpt(fd uintptr, key, value int) error {
-	return windows.SetsockoptInt(windows.Handle(fd), key, syscall.SO_REUSEADDR, value)
+func setSockOptREUSE(fd uintptr) error {
+	return windows.SetsockoptInt(windows.Handle(fd), windows.SOL_SOCKET, windows.SO_REUSEADDR, 1)
+}
+
+func setSockOptIPTOS(fd uintptr, tos int) error {
+	return windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IP, windows.IP_TOS, tos)
+}
+
+func setSockOptIPTTL(fd uintptr, ttl int) error {
+	return windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IP, windows.IP_TTL, ttl)
+}
+
+func setSockOptIPTOSFromConn(c *net.UDPConn, tos int) error {
+	fmt.Fprintf(os.Stderr, "setSockOptIPTOSFromConn: not implemented on Windows\n")
+	return nil
+}
+
+func setSockOptIPTTLFromConn(c *net.UDPConn, ttl int) error {
+	fmt.Fprintf(os.Stderr, "setSockOptIPTTLFromConn: not implemented on Windows\n")
+	return nil
 }

--- a/setsockopt_windows.go
+++ b/setsockopt_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package srt
+
+import (
+	"golang.org/x/sys/windows"
+	"syscall"
+)
+
+func setSockOpt(fd uintptr, key, value int) error {
+	return windows.SetsockoptInt(windows.Handle(fd), key, syscall.SO_REUSEADDR, value)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -23,6 +23,10 @@ github.com/stretchr/testify/require
 # golang.org/x/crypto v0.9.0
 ## explicit; go 1.17
 golang.org/x/crypto/pbkdf2
+# golang.org/x/sys v0.8.0
+## explicit; go 1.17
+golang.org/x/sys/internal/unsafeheader
+golang.org/x/sys/windows
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3


### PR DESCRIPTION
Basic support for Windows by making a separate version of setSockOpt for Windows.

Cannot access the right level to do it in the dial function, though.

The GitHub test harness has not yet been updated with Windows tests, but that should be done.

When testing towards one SRT source, the Windows version hangs on Read, while the MacOS version does not.
This is not yet thoroughly investigated.