### PR TITLE
fix crash in liveReceive

### DIFF
--- a/internal/congestion/live.go
+++ b/internal/congestion/live.go
@@ -579,8 +579,9 @@ func (r *liveReceive) periodicACK(now uint64) (ok bool, sequenceNumber circular.
 			maxPktTsbpdTime = p.Header().PktTsbpdTime
 
 			if e != nil {
-				e = e.Next()
-				p = e.Value.(packet.Packet)
+				if e = e.Next(); e != nil {
+					p = e.Value.(packet.Packet)
+				}
 			}
 		}
 


### PR DESCRIPTION
Hello, in `liveReceive.periodicACK` there's a `Element.Next()` that is used without checking whether it's nil or not. This leads to occasional crashes. This patch fixes the issue.