### PR TITLE
use crypto/rand instead of math/rand

### DIFF
--- a/internal/net/syncookie.go
+++ b/internal/net/syncookie.go
@@ -2,11 +2,65 @@ package net
 
 import (
 	"crypto/md5"
+	"crypto/rand"
 	"encoding/binary"
-	"math/rand"
 	"strconv"
 	"time"
 )
+
+func randInt63() (int64, error) {
+	var b [8]byte
+	_, err := rand.Read(b[:])
+	if err != nil {
+		return 0, err
+	}
+
+	return int64(uint64(b[0]&0b01111111)<<56 | uint64(b[1])<<48 | uint64(b[2])<<40 | uint64(b[3])<<32 |
+		uint64(b[4])<<24 | uint64(b[5])<<16 | uint64(b[6])<<8 | uint64(b[7])), nil
+}
+
+// https://cs.opensource.google/go/go/+/refs/tags/go1.20.4:src/math/rand/rand.go;l=119
+func randInt63n(n int64) (int64, error) {
+	if n&(n-1) == 0 { // n is power of two, can mask
+		r, err := randInt63()
+		if err != nil {
+			return 0, err
+		}
+		return r & (n - 1), nil
+	}
+
+	max := int64((1 << 63) - 1 - (1<<63)%uint64(n))
+
+	v, err := randInt63()
+	if err != nil {
+		return 0, err
+	}
+
+	for v > max {
+		v, err = randInt63()
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	return v % n, nil
+}
+
+// https://www.calhoun.io/creating-random-strings-in-go/
+func randomString(length int) (string, error) {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+	b := make([]byte, length)
+	for i := range b {
+		j, err := randInt63n(int64(len(charset)))
+		if err != nil {
+			return "", err
+		}
+		b[i] = charset[int(j)]
+	}
+
+	return string(b), nil
+}
 
 type SYNCookie struct {
 	secret1 string
@@ -19,8 +73,8 @@ func defaultCounter() int64 {
 	return time.Now().Unix() >> 6
 }
 
-func NewSYNCookie(daddr string, seed int64, counter func() int64) SYNCookie {
-	s := SYNCookie{
+func NewSYNCookie(daddr string, counter func() int64) (*SYNCookie, error) {
+	s := &SYNCookie{
 		daddr:   daddr,
 		counter: counter,
 	}
@@ -29,22 +83,18 @@ func NewSYNCookie(daddr string, seed int64, counter func() int64) SYNCookie {
 		s.counter = defaultCounter
 	}
 
-	// https://www.calhoun.io/creating-random-strings-in-go/
-	charset := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	seededRand := rand.New(rand.NewSource(seed))
-
-	stringWithCharset := func(length int, charset string) string {
-		b := make([]byte, length)
-		for i := range b {
-			b[i] = charset[seededRand.Intn(len(charset))]
-		}
-		return string(b)
+	var err error
+	s.secret1, err = randomString(32)
+	if err != nil {
+		return nil, err
 	}
 
-	s.secret1 = stringWithCharset(32, charset)
-	s.secret2 = stringWithCharset(32, charset)
+	s.secret2, err = randomString(32)
+	if err != nil {
+		return nil, err
+	}
 
-	return s
+	return s, err
 }
 
 func (s *SYNCookie) Get(saddr string) uint32 {

--- a/internal/net/syncookie_test.go
+++ b/internal/net/syncookie_test.go
@@ -9,12 +9,13 @@ import (
 func TestSYNCookie(t *testing.T) {
 	counter := int64(0)
 
-	s := NewSYNCookie("192.168.0.1", 42, func() int64 {
+	s, err := NewSYNCookie("192.168.0.1", func() int64 {
 		return counter
 	})
+	require.NoError(t, err)
 
-	require.Equal(t, "dl2INvNSQTZ5zQu9MxNmGyAVmNkB33io", s.secret1)
-	require.Equal(t, "nwj2qrsh3xyC8OmCp1gObD0iOtQNQsLi", s.secret2)
+	s.secret1 = "dl2INvNSQTZ5zQu9MxNmGyAVmNkB33io"
+	s.secret2 = "nwj2qrsh3xyC8OmCp1gObD0iOtQNQsLi"
 
 	cookie := s.Get("192.168.0.2")
 

--- a/listen.go
+++ b/listen.go
@@ -150,7 +150,7 @@ type listener struct {
 	rcvQueue chan packet.Packet
 	sndQueue chan packet.Packet
 
-	syncookie srtnet.SYNCookie
+	syncookie *srtnet.SYNCookie
 
 	shutdown     bool
 	shutdownLock sync.RWMutex
@@ -210,7 +210,11 @@ func Listen(network, address string, config Config) (Listener, error) {
 	ln.rcvQueue = make(chan packet.Packet, 2048)
 	ln.sndQueue = make(chan packet.Packet, 2048)
 
-	ln.syncookie = srtnet.NewSYNCookie(ln.addr.String(), time.Now().UnixNano(), nil)
+	ln.syncookie, err = srtnet.NewSYNCookie(ln.addr.String(), nil)
+	if err != nil {
+		ln.Close()
+		return nil, err
+	}
 
 	ln.doneChan = make(chan error)
 


### PR DESCRIPTION
`math/rand` has a predictable output that entirely depends on the seed, that can be estimated by using brute force attacks. It is advised to replace it with `crypto/rand` even in features that apparently don't play a role in security.