### PR TITLE
split ListenAndServe() into Listen() and Serve() and fix race condition in tests

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -3,7 +3,6 @@ package srt
 import (
 	"bytes"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -51,26 +50,18 @@ func TestEncryption(t *testing.T) {
 		},
 	}
 
+	err := server.Listen()
+	require.NoError(t, err)
+
 	defer server.Shutdown()
 
-	wgListen := sync.WaitGroup{}
-	wgListen.Add(1)
-
 	go func() {
-		wgListen.Done()
-		if err := server.ListenAndServe(); err != nil {
-			if err == ErrServerClosed {
-				return
-			}
-
-			if !assert.NoError(t, err) {
-				panic(err.Error())
-			}
+		err := server.Serve()
+		if err == ErrServerClosed {
+			return
 		}
+		require.NoError(t, err)
 	}()
-
-	// Wait for goroutine to be started
-	wgListen.Wait()
 
 	{
 		// Reject connection if wrong password is set
@@ -195,26 +186,18 @@ func TestEncryptionKeySwap(t *testing.T) {
 		},
 	}
 
+	err := server.Listen()
+	require.NoError(t, err)
+
 	defer server.Shutdown()
 
-	wgListen := sync.WaitGroup{}
-	wgListen.Add(1)
-
 	go func() {
-		wgListen.Done()
-		if err := server.ListenAndServe(); err != nil {
-			if err == ErrServerClosed {
-				return
-			}
-
-			if !assert.NoError(t, err) {
-				panic(err.Error())
-			}
+		err := server.Serve()
+		if err == ErrServerClosed {
+			return
 		}
+		require.NoError(t, err)
 	}()
-
-	// Wait for goroutine to be started
-	wgListen.Wait()
 
 	// Test transmitting encrypted messages with key swap in between
 
@@ -328,26 +311,18 @@ func TestStats(t *testing.T) {
 		},
 	}
 
+	err := server.Listen()
+	require.NoError(t, err)
+
 	defer server.Shutdown()
 
-	wgListen := sync.WaitGroup{}
-	wgListen.Add(1)
-
 	go func() {
-		wgListen.Done()
-		if err := server.ListenAndServe(); err != nil {
-			if err == ErrServerClosed {
-				return
-			}
-
-			if !assert.NoError(t, err) {
-				panic(err.Error())
-			}
+		err := server.Serve()
+		if err == ErrServerClosed {
+			return
 		}
+		require.NoError(t, err)
 	}()
-
-	// Wait for goroutine to be started
-	wgListen.Wait()
 
 	statsReader := Statistics{}
 	statsWriter := Statistics{}

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -42,21 +42,16 @@ func TestPubSub(t *testing.T) {
 		},
 	}
 
-	serverWg := sync.WaitGroup{}
-	serverWg.Add(1)
+	err := server.Listen()
+	require.NoError(t, err)
 
-	go func(s *Server) {
-		serverWg.Done()
-		if err := s.ListenAndServe(); err != nil {
-			if err == ErrServerClosed {
-				return
-			}
-
-			require.NoError(t, err)
+	go func() {
+		err := server.Serve()
+		if err == ErrServerClosed {
+			return
 		}
-	}(&server)
-
-	serverWg.Wait()
+		require.NoError(t, err)
+	}()
 
 	readerWg := sync.WaitGroup{}
 	readerWg.Add(2)


### PR DESCRIPTION
Hello again, 

This code won't produce the desired effect:

```go
	wgListen := sync.WaitGroup{}
	wgListen.Add(1)
	defer server.Shutdown()

	go func() {
		wgListen.Done()
		if err := server.ListenAndServe(); err != nil {
			if err == ErrServerClosed {
				return
			}

			if !assert.NoError(t, err) {
				panic(err.Error())
			}
		}
		require.NoError(t, err)
	}()

	// Wait for goroutine to be started
	wgListen.Wait()
```

It indeed waits for the routine to start, but it doesn't wait for the server to start. This is because it's currently impossible to split the listening from the serving operation.

This patch splits the `Server.ListenAndServe()` method into two submethods, `Listen()` and `Serve()`, in a way very similar to what the `net/http` library does:

https://cs.opensource.google/go/go/+/refs/tags/go1.20.6:src/net/http/server.go;l=3270

In this way it's possible to build software that can check listening errors before starting a new routine, and it's also possible to fix tests - the code written above becomes:

```go
	err := server.Listen()
	require.NoError(t, err)

	defer server.Shutdown()

	go func() {
		err := server.Serve()
		if err == ErrServerClosed {
			return
		}
		require.NoError(t, err)
	}()
```

Now there's a 100% certainty that the listener is available on the main routine.

