### PR TITLE
remove redundant check in crypto

### DIFF
--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -261,14 +261,6 @@ func (c *crypto) calculateKEK(passphrase string, salt []byte, keyLength int) []b
 
 // prng generates a random sequence of byte into the given slice p.
 func (c *crypto) prng(p []byte) error {
-	n, err := rand.Read(p)
-	if err != nil {
-		return err
-	}
-
-	if n != len(p) {
-		return fmt.Errorf("crypto: random byte sequence is too short")
-	}
-
-	return nil
+	_, err := rand.Read(p)
+	return err
 }


### PR DESCRIPTION
Hello, `rand.Read()` is based on `io.ReadFull`, which already returns an error when `n != len(p)`:

https://cs.opensource.google/go/go/+/refs/tags/go1.20.6:src/crypto/rand/rand.go;l=24

https://cs.opensource.google/go/go/+/refs/tags/go1.20.6:src/io/io.go;l=351

Furthermore, this is also written into the documentation:

> Read is a helper function that calls Reader.Read using io.ReadFull. On return, n == len(b) if and only if err == nil. 

Therefore, checking `n != len(p)` after `rand.Read()` is useless.