### PR TITLE
fix race condition in liveReceive.Stats() and liveSend.Stats()

### DIFF
--- a/internal/congestion/live.go
+++ b/internal/congestion/live.go
@@ -77,8 +77,8 @@ func NewLiveSend(config SendConfig) Sender {
 }
 
 func (s *liveSend) Stats() SendStats {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
 	s.statistics.UsPktSndPeriod = s.pktSndPeriod
 	s.statistics.BytePayload = uint64(s.avgPayloadSize)
@@ -389,8 +389,8 @@ func NewLiveReceive(config ReceiveConfig) Receiver {
 }
 
 func (r *liveReceive) Stats() ReceiveStats {
-	r.lock.RLock()
-	defer r.lock.RUnlock()
+	r.lock.Lock()
+	defer r.lock.Unlock()
 
 	r.statistics.BytePayload = uint64(r.avgPayloadSize)
 	r.statistics.MbpsEstimatedRecvBandwidth = r.rate.bytesPerSecond * 8 / 1024 / 1024
@@ -539,8 +539,8 @@ func (r *liveReceive) Push(pkt packet.Packet) {
 }
 
 func (r *liveReceive) periodicACK(now uint64) (ok bool, sequenceNumber circular.Number, lite bool) {
-	r.lock.RLock()
-	defer r.lock.RUnlock()
+	r.lock.Lock()
+	defer r.lock.Unlock()
 
 	// 4.8.1. Packet Acknowledgement (ACKs, ACKACKs)
 	if now-r.lastPeriodicACK < r.periodicACKInterval {


### PR DESCRIPTION
When `Conn.Stats()` is called, `liveSend.Stats()` and `liveReceive.Stats()` are also called. They both write to `live*.statistics` while it is also read and written in parallel by tick routines.

This patch fixes the issue by protecting  `live*.statistics`  with the existing mutex.