### PR TITLE
Fix race condition when disposing late packets

### DIFF
--- a/listen.go
+++ b/listen.go
@@ -148,7 +148,9 @@ type listener struct {
 	start time.Time
 
 	rcvQueue chan packet.Packet
-	sndQueue chan packet.Packet
+
+	sendMutex sync.Mutex
+	sendData  bytes.Buffer
 
 	syncookie *srtnet.SYNCookie
 
@@ -157,7 +159,6 @@ type listener struct {
 	shutdownOnce sync.Once
 
 	stopReader context.CancelFunc
-	stopWriter context.CancelFunc
 
 	doneChan chan error
 }
@@ -208,7 +209,6 @@ func Listen(network, address string, config Config) (Listener, error) {
 	ln.backlog = make(chan connRequest, 128)
 
 	ln.rcvQueue = make(chan packet.Packet, 2048)
-	ln.sndQueue = make(chan packet.Packet, 2048)
 
 	ln.syncookie, err = srtnet.NewSYNCookie(ln.addr.String(), nil)
 	if err != nil {
@@ -223,10 +223,6 @@ func Listen(network, address string, config Config) (Listener, error) {
 	var readerCtx context.Context
 	readerCtx, ln.stopReader = context.WithCancel(context.Background())
 	go ln.reader(readerCtx)
-
-	var writerCtx context.Context
-	writerCtx, ln.stopWriter = context.WithCancel(context.Background())
-	go ln.writer(writerCtx)
 
 	go func() {
 		buffer := make([]byte, config.MSS) // MTU size
@@ -436,7 +432,6 @@ func (ln *listener) Close() {
 		ln.lock.RUnlock()
 
 		ln.stopReader()
-		ln.stopWriter()
 
 		ln.log("listen", func() string { return "closing socket" })
 
@@ -489,49 +484,29 @@ func (ln *listener) reader(ctx context.Context) {
 	}
 }
 
+// this function must be synchronous in order to allow to safely call Packet.Decommission() afterward.
 func (ln *listener) send(p packet.Packet) {
-	// non-blocking
-	select {
-	case ln.sndQueue <- p:
-	default:
-		ln.log("listen", func() string { return "send queue is full" })
+	ln.sendMutex.Lock()
+	defer ln.sendMutex.Unlock()
+
+	ln.sendData.Reset()
+
+	if err := p.Marshal(&ln.sendData); err != nil {
+		p.Decommission()
+		ln.log("packet:send:error", func() string { return "marshalling packet failed" })
+		return
 	}
-}
 
-func (ln *listener) writer(ctx context.Context) {
-	defer func() {
-		ln.log("listen", func() string { return "left writer loop" })
-	}()
+	buffer := ln.sendData.Bytes()
 
-	ln.log("listen", func() string { return "writer loop started" })
+	ln.log("packet:send:dump", func() string { return p.Dump() })
 
-	var data bytes.Buffer
+	// Write the packet's contents to the wire
+	ln.pc.WriteTo(buffer, p.Header().Addr)
 
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case p := <-ln.sndQueue:
-			data.Reset()
-
-			if err := p.Marshal(&data); err != nil {
-				p.Decommission()
-				ln.log("packet:send:error", func() string { return "marshalling packet failed" })
-				continue
-			}
-
-			buffer := data.Bytes()
-
-			ln.log("packet:send:dump", func() string { return p.Dump() })
-
-			// Write the packet's contents to the wire
-			ln.pc.WriteTo(buffer, p.Header().Addr)
-
-			if p.Header().IsControlPacket {
-				// Control packets can be decommissioned because they will not be sent again (data packets might be retransferred)
-				p.Decommission()
-			}
-		}
+	if p.Header().IsControlPacket {
+		// Control packets can be decommissioned because they will not be sent again (data packets might be retransferred)
+		p.Decommission()
 	}
 }
 


### PR DESCRIPTION
in `liveSend`, packets are gathered and sent periodically with `deliver()`:

https://github.com/datarhei/gosrt/blob/e3ca3449f90e2c8e46d50fac493bd752490bb18e/internal/congestion/live.go#L174-L179

Shortly after `deliver()`, `liveSend` may dispose packet content through `Packet.Decommission()`:

https://github.com/datarhei/gosrt/blob/e3ca3449f90e2c8e46d50fac493bd752490bb18e/internal/congestion/live.go#L205-L215

This causes a race condition, since `deliver()` (that is `Listener.Send()`) is asynchronous, and packets may not have been marshaled and sent yet:

https://github.com/datarhei/gosrt/blob/e3ca3449f90e2c8e46d50fac493bd752490bb18e/listen.go#L492-L499

This patch fixes the issue by making `Listener.Send()` synchronous.

This may be less efficient (MAYBE, because a queue has a performance cost and this patch removes a queue) but doesn't impact the stability of the server: i've checked all calls to this method, and they are all in dedicated routines, one for handling handshakes and one for each client, thus reading and sending are still in two separate routines, and a delay in a specific client routine won't impact the reading routine or other clients.