### PR TITLE
Fix crash in client and server with invalid handshake packets

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -425,6 +425,14 @@ func (dl *dialer) handleHandshake(p packet.Packet) {
 		sendTsbpdDelay := uint16(dl.config.PeerLatency.Milliseconds())
 
 		if cif.Version == 5 {
+			if cif.SRTHS == nil {
+				dl.connChan <- connResponse{
+					conn: nil,
+					err:  fmt.Errorf("missing handshake extension"),
+				}
+				return
+			}
+
 			// Check if the peer version is sufficient
 			if cif.SRTHS.SRTVersion < dl.config.MinVersion {
 				dl.sendShutdown(cif.SRTSocketId)

--- a/listen.go
+++ b/listen.go
@@ -698,6 +698,16 @@ func (ln *listener) handleHandshake(p packet.Packet) {
 				return
 			}
 		} else if cif.Version == 5 {
+			if cif.SRTHS == nil {
+				cif.HandshakeType = packet.HandshakeType(REJ_ROGUE)
+				ln.log("handshake:recv:error", func() string { return "missing handshake extension" })
+				p.MarshalCIF(cif)
+				ln.log("handshake:send:dump", func() string { return p.Dump() })
+				ln.log("handshake:send:cif", func() string { return cif.String() })
+				ln.send(p)
+				return
+			}
+
 			// Check if the peer version is sufficient
 			if cif.SRTHS.SRTVersion < config.MinVersion {
 				cif.HandshakeType = packet.HandshakeType(REJ_VERSION)


### PR DESCRIPTION
In both Dial() and Listen(), if the peer sends a V5 handshake packet without the extension field, the library crashes. This patch fixes the issue and adds unit tests.