### PR TITLE
Add a configuration option to drop packets from an unexpected source address

### DIFF
--- a/config.go
+++ b/config.go
@@ -169,6 +169,9 @@ type Config struct {
 
 	// An implementation of the Logger interface
 	Logger Logger
+
+	// if a new IP starts sending data on an existing socket id, allow it
+	AllowPeerIpChange bool
 }
 
 // DefaultConfig is the default configuration for a SRT connection
@@ -209,6 +212,7 @@ var defaultConfig Config = Config{
 	TooLatePacketDrop:     true,
 	TransmissionType:      "live",
 	TSBPDMode:             true,
+	AllowPeerIpChange:     false,
 }
 
 // DefaultConfig returns the default configuration for Dial and Listen.

--- a/listen.go
+++ b/listen.go
@@ -407,6 +407,14 @@ func (ln *listener) reader(ctx context.Context) {
 				break
 			}
 
+			if !ln.config.AllowPeerIpChange {
+				if p.Header().Addr.String() != conn.RemoteAddr().String() {
+					// ignore the packet, it's not from the expected peer
+					// https://haivision.github.io/srt-rfc/draft-sharabayko-srt.html#name-security-considerations
+					break
+				}
+			}
+
 			conn.push(p)
 		}
 	}


### PR DESCRIPTION
If an attacker has the socket id of an existing connection (either through sniffing traffic - the headers aren't encrypted - or guessing, since they're only 32 bit IDs), they can send packets that will be processed as being part of an existing connection.

This could be used to interfere with an existing connection, either adding corrupt data or causing the SRT connection to be terminated, for example. 

So, add a configuration option to keep this behaviour (but default it to off because it can be unsafe). If this behaviour isn't wanted (the new default), packets from a different address are dropped.

