### PR TITLE
Generate socket id randomly and validate that it's not already in use

### DIFF
--- a/conn_request.go
+++ b/conn_request.go
@@ -374,7 +374,7 @@ func (req *connRequest) Accept() (Conn, error) {
 	// Create a new socket ID
 	socketId, err := req.generateSocketId()
 	if err != nil {
-		return nil, fmt.Errorf("could not generate socket id")
+		return nil, fmt.Errorf("could not generate socket id: %w", err)
 	}
 
 	// Select the largest TSBPD delay advertised by the caller, but at least 120ms


### PR DESCRIPTION
Currently, the socket id is generated based on a microsecond timestamp. Two sufficiently-close-in-time connection requests, or two connection requests about 1.2 hours apart (the 32 bit value here rolls over every ~1.2 hours) could accidentally use the same socket id - and the code doesn't check for this case.

So, instead, we do two things:
 - generate the socket id randomly
 - validate that it's not in use

We then iterate a few times as needed to ensure that in the event that the same random number is generated, we try again.