### PR TITLE
Keep packets encrypted on retransmission

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -546,7 +546,9 @@ func (c *srtConn) pop(p packet.Packet) {
 		c.cryptoLock.Lock()
 		if c.crypto != nil {
 			p.Header().KeyBaseEncryptionFlag = c.keyBaseEncryption
-			c.crypto.EncryptOrDecryptPayload(p.Data(), p.Header().KeyBaseEncryptionFlag, p.Header().PacketSequenceNumber.Val())
+			if !p.Header().RetransmittedPacketFlag {
+				c.crypto.EncryptOrDecryptPayload(p.Data(), p.Header().KeyBaseEncryptionFlag, p.Header().PacketSequenceNumber.Val())
+			}
 
 			c.kmPreAnnounceCountdown--
 			c.kmRefreshCountdown--


### PR DESCRIPTION
I noticed that SRT packets were being unencrypted when being sent on retransmission.

Each time a packet goes through the `func (*srtConn) pop(packet.Packet)` function it is run through the `c.crypto.EncryptOrDecryptPayload`. Since this encryption/decryption is performed on the payload inplace when a packet with an encrypted payload is retransmitted the payload will be decrypted prior to sending. The result is that the receiver will "decrypt" the unencrypted payload which makes it appear to be corrupted.