### PR TITLE
fix broken connections in case of high latency

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -191,7 +191,7 @@ type srtConn struct {
 	readBuffer bytes.Buffer
 
 	onSend     func(p packet.Packet)
-	onShutdown func(socketId uint32)
+	onShutdown func(*srtConn)
 
 	tick time.Duration
 
@@ -234,7 +234,7 @@ type srtConnConfig struct {
 	crypto                      crypto.Crypto
 	keyBaseEncryption           packet.PacketEncryption
 	onSend                      func(p packet.Packet)
-	onShutdown                  func(socketId uint32)
+	onShutdown                  func(*srtConn)
 	logger                      Logger
 }
 
@@ -264,7 +264,7 @@ func newSRTConn(config srtConnConfig) *srtConn {
 	}
 
 	if c.onShutdown == nil {
-		c.onShutdown = func(socketId uint32) {}
+		c.onShutdown = func(*srtConn) {}
 	}
 
 	c.nextACKNumber = circular.New(1, packet.MAX_TIMESTAMP)
@@ -1415,7 +1415,7 @@ func (c *srtConn) close() {
 		c.log("connection:close", func() string { return "shutdown" })
 
 		go func() {
-			c.onShutdown(c.socketId)
+			c.onShutdown(c)
 		}()
 	})
 }

--- a/dial.go
+++ b/dial.go
@@ -513,7 +513,7 @@ func (dl *dialer) handleHandshake(p packet.Packet) {
 			crypto:                      dl.crypto,
 			keyBaseEncryption:           packet.EvenKeyEncrypted,
 			onSend:                      dl.send,
-			onShutdown:                  func(socketId uint32) { dl.Close() },
+			onShutdown:                  func(*srtConn) { dl.Close() },
 			logger:                      dl.config.Logger,
 		})
 

--- a/listen.go
+++ b/listen.go
@@ -121,10 +121,10 @@ type listener struct {
 
 	config Config
 
-	backlog  chan packet.Packet
-	connReqs map[uint32]*connRequest
-	conns    map[uint32]*srtConn
-	lock     sync.RWMutex
+	backlog     chan packet.Packet
+	conns       map[uint32]*srtConn
+	connsByPeer map[uint32]*srtConn
+	lock        sync.RWMutex
 
 	start time.Time
 
@@ -190,8 +190,8 @@ func Listen(network, address string, config Config) (Listener, error) {
 		return nil, fmt.Errorf("listen: no local address")
 	}
 
-	ln.connReqs = make(map[uint32]*connRequest)
 	ln.conns = make(map[uint32]*srtConn)
+	ln.connsByPeer = make(map[uint32]*srtConn)
 
 	ln.backlog = make(chan packet.Packet, 128)
 
@@ -326,9 +326,10 @@ func (ln *listener) error() error {
 	return ln.doneErr
 }
 
-func (ln *listener) handleShutdown(socketId uint32) {
+func (ln *listener) handleShutdown(c *srtConn) {
 	ln.lock.Lock()
-	delete(ln.conns, socketId)
+	delete(ln.conns, c.socketId)
+	delete(ln.connsByPeer, c.peerSocketId)
 	ln.lock.Unlock()
 }
 


### PR DESCRIPTION
related issue: https://github.com/bluenviron/mediamtx/issues/3756

When listening and accepting an incoming connection request, the response might be received by the peer with some delay due to latency. This causes the peer to send a second connection request, that is not detected as duplicate because the first connection request has already been removed from the map that is used to check for duplicates
(connReqs), so it is treated as a brand new connection request, breaking the first connection.

This patch fixes the issue by introducing another map (connByPeer) that is used to check whether a connection request is associated to an already-accepted connection.