### PR TITLE
Implement adaptive reorder tolerance from libsrt

### DIFF
--- a/congestion/congestion.go
+++ b/congestion/congestion.go
@@ -53,6 +53,12 @@ type Receiver interface {
 
 	// SetNAKInterval sets the interval between two periodic NAK messages to the sender in microseconds.
 	SetNAKInterval(nakInterval uint64)
+
+	// ReorderTolerance returns the current dynamic reorder tolerance value.
+	ReorderTolerance() int
+
+	// SetReorderSupport enables or disables adaptive reorder tolerance based on peer REXMIT capability.
+	SetReorderSupport(enabled bool)
 }
 
 // SendStats are collected statistics from a sender
@@ -121,4 +127,7 @@ type ReceiveStats struct {
 	MbpsEstimatedLinkCapacity  float64
 
 	PktLossRate float64
+
+	PktReorderTolerance int
+	PktReorderDistance  int
 }

--- a/congestion/congestion.go
+++ b/congestion/congestion.go
@@ -56,9 +56,6 @@ type Receiver interface {
 
 	// ReorderTolerance returns the current dynamic reorder tolerance value.
 	ReorderTolerance() int
-
-	// SetReorderSupport enables or disables adaptive reorder tolerance based on peer REXMIT capability.
-	SetReorderSupport(enabled bool)
 }
 
 // SendStats are collected statistics from a sender

--- a/congestion/live/fake.go
+++ b/congestion/live/fake.go
@@ -180,3 +180,7 @@ func (r *fakeLiveReceive) SetNAKInterval(nakInterval uint64) {
 
 	r.periodicNAKInterval = nakInterval
 }
+
+func (r *fakeLiveReceive) ReorderTolerance() int { return 0 }
+
+func (r *fakeLiveReceive) SetReorderSupport(enabled bool) {}

--- a/congestion/live/fake.go
+++ b/congestion/live/fake.go
@@ -182,5 +182,3 @@ func (r *fakeLiveReceive) SetNAKInterval(nakInterval uint64) {
 }
 
 func (r *fakeLiveReceive) ReorderTolerance() int { return 0 }
-
-func (r *fakeLiveReceive) SetReorderSupport(enabled bool) {}

--- a/congestion/live/receive.go
+++ b/congestion/live/receive.go
@@ -57,7 +57,6 @@ type receiver struct {
 	// Adaptive reorder tolerance state (mirrors libsrt m_iReorderTolerance)
 	maxReorderTolerance   int
 	reorderTolerance      int
-	reorderSupport        bool
 	consecOrderedDelivery int
 	consecEarlyDelivery   int
 	freshLoss            []freshLossEntry
@@ -97,7 +96,6 @@ func NewReceiver(config ReceiveConfig) congestion.Receiver {
 
 		maxReorderTolerance: config.MaxReorderTolerance,
 		reorderTolerance:    config.MaxReorderTolerance,
-		reorderSupport:      false,
 
 		sendACK: config.OnSendACK,
 		sendNAK: config.OnSendNAK,
@@ -277,9 +275,9 @@ func (r *receiver) Push(pkt packet.Packet) {
 		r.statistics.PktLoss += lossLen
 		r.statistics.ByteLoss += lossLen * uint64(r.avgPayloadSize)
 
-		// Determine initial loss TTL based on reorder support
+		// Determine initial loss TTL based on adaptive reorder tolerance support
 		initialLossTTL := 0
-		if r.reorderSupport {
+		if r.maxReorderTolerance > 0 {
 			initialLossTTL = r.reorderTolerance
 		}
 
@@ -512,28 +510,12 @@ func (r *receiver) ReorderTolerance() int {
 	return r.reorderTolerance
 }
 
-func (r *receiver) SetReorderSupport(enabled bool) {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-
-	r.reorderSupport = enabled
-	if enabled {
-		r.reorderTolerance = r.maxReorderTolerance
-	} else {
-		r.reorderTolerance = 0
-		r.consecOrderedDelivery = 0
-		r.consecEarlyDelivery = 0
-		r.freshLoss = nil
-		r.traceReorderDistance = 0
-	}
-}
-
 // unlose adjusts reorder tolerance for a belated packet. Mirrors libsrt CUDT::unlose().
 func (r *receiver) unlose(pkt packet.Packet) {
 	hasIncreasedTolerance := false
 	wasReordered := false
 
-	if r.reorderSupport {
+	if r.maxReorderTolerance > 0 {
 		// Original (not retransmitted) belated packet means reordering
 		wasReordered = !pkt.Header().RetransmittedPacketFlag
 		if wasReordered {
@@ -553,7 +535,7 @@ func (r *receiver) unlose(pkt packet.Packet) {
 	}
 
 	// Early return if adaptive reorder is not active (mirrors libsrt)
-	if !r.reorderSupport || r.reorderTolerance == 0 {
+	if r.maxReorderTolerance == 0 || r.reorderTolerance == 0 {
 		return
 	}
 
@@ -578,7 +560,7 @@ func (r *receiver) unlose(pkt packet.Packet) {
 
 // updateOrderedDelivery tracks in-order delivery and decays tolerance after 50 consecutive.
 func (r *receiver) updateOrderedDelivery(wasSentInOrder bool) {
-	if !r.reorderSupport {
+	if r.maxReorderTolerance == 0 {
 		return
 	}
 

--- a/conn_request.go
+++ b/conn_request.go
@@ -192,7 +192,7 @@ func newConnRequest(ln *listener, p packet.Packet) *connRequest {
 			}
 
 			// Check the required SRT flags
-			if !cif.SRTHS.SRTFlags.TSBPDSND || !cif.SRTHS.SRTFlags.TSBPDRCV || !cif.SRTHS.SRTFlags.TLPKTDROP || !cif.SRTHS.SRTFlags.PERIODICNAK || !cif.SRTHS.SRTFlags.REXMITFLG {
+			if !cif.SRTHS.SRTFlags.TSBPDSND || !cif.SRTHS.SRTFlags.TSBPDRCV || !cif.SRTHS.SRTFlags.TLPKTDROP || !cif.SRTHS.SRTFlags.PERIODICNAK {
 				cif.HandshakeType = packet.HandshakeType(REJ_ROGUE)
 				ln.log("handshake:recv:error", func() string { return "not all required flags are set" })
 				p.MarshalCIF(cif)

--- a/connection.go
+++ b/connection.go
@@ -918,13 +918,6 @@ func (c *srtConn) handleHSRequest(p packet.Packet) {
 		return
 	}
 
-	if cif.SRTFlags.REXMITFLG {
-		// Peer supports REXMIT flag, enable adaptive reorder tolerance
-		c.recv.SetReorderSupport(true)
-	} else {
-		c.log("control:recv:HSRes:warn", func() string { return "peer does not support REXMITFLG, adaptive reorder tolerance disabled" })
-	}
-
 	// we as receiver don't need this
 	cif.SRTFlags.TSBPDSND = false
 
@@ -1011,13 +1004,6 @@ func (c *srtConn) handleHSResponse(p packet.Packet) {
 			c.close()
 
 			return
-		}
-
-		if cif.SRTFlags.REXMITFLG {
-			// Peer supports REXMIT flag, enable adaptive reorder tolerance
-			c.recv.SetReorderSupport(true)
-		} else {
-			c.log("control:recv:HSRes:warn", func() string { return "peer does not support REXMITFLG, adaptive reorder tolerance disabled" })
 		}
 
 		// These flag was introduced in HSv5 and should not be set in HSv4

--- a/dial.go
+++ b/dial.go
@@ -446,7 +446,7 @@ func (dl *dialer) handleHandshake(p packet.Packet) {
 			}
 
 			// Check the required SRT flags
-			if !cif.SRTHS.SRTFlags.TSBPDSND || !cif.SRTHS.SRTFlags.TSBPDRCV || !cif.SRTHS.SRTFlags.TLPKTDROP || !cif.SRTHS.SRTFlags.PERIODICNAK || !cif.SRTHS.SRTFlags.REXMITFLG {
+			if !cif.SRTHS.SRTFlags.TSBPDSND || !cif.SRTHS.SRTFlags.TSBPDRCV || !cif.SRTHS.SRTFlags.TLPKTDROP || !cif.SRTHS.SRTFlags.PERIODICNAK {
 				dl.sendShutdown(cif.SRTSocketId)
 
 				dl.connChan <- connResponse{


### PR DESCRIPTION
- Add receiver-side adaptive reorder tolerance with REXMIT flag negotiation
- Defer NAKs via fresh-loss TTL handling and revoke on TLPKTDROP