### PR TITLE
Fix MsBuf in receiver stats reporting 0.

### DIFF
--- a/congestion/live/receive.go
+++ b/congestion/live/receive.go
@@ -299,6 +299,7 @@ func (r *receiver) periodicACK(now uint64) (ok bool, sequenceNumber circular.Num
 		if p.Header().PacketSequenceNumber.Equals(ackSequenceNumber.Inc()) {
 			ackSequenceNumber = p.Header().PacketSequenceNumber
 			maxPktTsbpdTime = p.Header().PktTsbpdTime
+			r.statistics.MsBuf = (maxPktTsbpdTime - minPktTsbpdTime) / 1_000
 			continue
 		}
 
@@ -314,8 +315,6 @@ func (r *receiver) periodicACK(now uint64) (ok bool, sequenceNumber circular.Num
 
 	r.lastPeriodicACK = now
 	r.nPackets = 0
-
-	r.statistics.MsBuf = (maxPktTsbpdTime - minPktTsbpdTime) / 1_000
 
 	return
 }


### PR DESCRIPTION
Changed periodicAck function in receive.go to recalculate MsBuf when an ack packet is received, rather than every tick. This prevents MsBuf from reporting 0mS if no new ack packets have been received.