### PR TITLE
feat: add ListenerControl callback to Config

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"syscall"
 	"time"
 )
 
@@ -169,6 +170,11 @@ type Config struct {
 
 	// An implementation of the Logger interface
 	Logger Logger
+
+	// ListenerControl is called on the raw socket file descriptor after
+	// gosrt's built-in options (SO_REUSEADDR, IP_TOS, IP_TTL) are set
+	// but before the socket is bound. Same signature as net.ListenConfig.Control.
+	ListenerControl func(network, address string, c syscall.RawConn) error
 
 	// if a new IP starts sending data on an existing socket id, allow it
 	AllowPeerIpChange bool

--- a/listen.go
+++ b/listen.go
@@ -9,6 +9,7 @@ import (
 	"net/netip"
 	"os"
 	"sync"
+	"syscall"
 	"time"
 
 	srtnet "github.com/datarhei/gosrt/net"
@@ -175,7 +176,15 @@ func Listen(network, address string, config Config) (Listener, error) {
 	}
 
 	lc := net.ListenConfig{
-		Control: ListenControl(config),
+		Control: func(network, address string, c syscall.RawConn) error {
+			if err := ListenControl(config)(network, address, c); err != nil {
+				return err
+			}
+			if config.ListenerControl != nil {
+				return config.ListenerControl(network, address, c)
+			}
+			return nil
+		},
 	}
 
 	network = "udp"

--- a/listen_test.go
+++ b/listen_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -25,6 +26,22 @@ func TestListenReuse(t *testing.T) {
 	require.NoError(t, err)
 
 	ln.Close()
+}
+
+func TestListenerControl(t *testing.T) {
+	called := false
+
+	config := DefaultConfig()
+	config.ListenerControl = func(network, address string, c syscall.RawConn) error {
+		called = true
+		return nil
+	}
+
+	ln, err := Listen("srt", "127.0.0.1:6003", config)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	require.True(t, called, "ListenerControl callback was not invoked")
 }
 
 func TestListen(t *testing.T) {


### PR DESCRIPTION
## Summary

Go's `net.ListenConfig` exposes a `Control` callback so callers can set arbitrary socket options on the raw fd before bind. gosrt hardcodes its own `ListenControl()` inside `Listen()` but provides no way for the caller to hook into the same mechanism.

This PR adds a `ListenerControl` field to `Config`, following the same signature as `net.ListenConfig.Control`. If set, it runs **after** gosrt's built-in socket options (`SO_REUSEADDR`, `IP_TOS`, `IP_TTL`) but **before** the socket is bound.

This lets callers like mediamtx set `SO_RCVBUF` (or any other socket option) without gosrt needing to know about application-specific details:

```go
conf.ListenerControl = func(network, address string, c syscall.RawConn) error {
    return c.Control(func(fd uintptr) {
        syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, 26214400)
    })
}
```

## Changes

- **`config.go`**: Add `ListenerControl func(network, address string, c syscall.RawConn) error` field to `Config`
- **`listen.go`**: Wrap the `net.ListenConfig.Control` callback to chain gosrt's built-in `ListenControl` with the caller's `ListenerControl` (if set)

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Builds cleanly against latest master
- Zero behavioral change when `ListenerControl` is nil (default)