### PR TITLE
Send the reply unpinned rather than dropping it, and report a failed send

### DIFF
--- a/listen.go
+++ b/listen.go
@@ -469,7 +469,12 @@ func (ln *listener) send(p packet.Packet) {
 	ln.log("packet:send:dump", func() string { return p.Dump() })
 
 	// Write the packet's contents to the wire
-	ln.pc.writeToFrom(buffer, p.Header().Addr, p.Header().LocalAddr)
+	if err := ln.pc.writeToFrom(buffer, p.Header().Addr, p.Header().LocalAddr); err != nil {
+		// Previously discarded. A send that fails here is invisible on both
+		// sides: the peer simply never hears back, and the handshake times out
+		// with nothing logged to explain it.
+		ln.log("packet:send:error", func() string { return "writing packet to the wire failed: " + err.Error() })
+	}
 
 	if p.Header().IsControlPacket {
 		// Control packets can be decommissioned because they will not be sent again (data packets might be retransferred)

--- a/listen_test.go
+++ b/listen_test.go
@@ -876,14 +876,12 @@ func TestListenDualStackWildcardAcceptsIPv4(t *testing.T) {
 	serverDone := make(chan struct{})
 	go func() {
 		defer close(serverDone)
+
 		req, err := ln.Accept2()
-		if err != nil {
-			return
-		}
+		require.NoError(t, err)
+
 		conn, err := req.Accept()
-		if err != nil {
-			return
-		}
+		require.NoError(t, err)
 		conn.Close()
 	}()
 

--- a/listen_test.go
+++ b/listen_test.go
@@ -856,3 +856,40 @@ func TestListenAcceptAndDiscardRepeatedHandshakes(t *testing.T) {
 	// wait some time to make sure that close(singleReqAccepted) is not triggered
 	time.Sleep(500 * time.Millisecond)
 }
+
+func TestListenDualStackWildcardAcceptsIPv4(t *testing.T) {
+	// A bare ":port" listener is a dual-stack AF_INET6 socket. An IPv4 caller
+	// must still complete the handshake.
+	//
+	// It did not on Darwin: the reply is sent with an ancillary control message
+	// to pin the source address, and sendmsg rejects that for an IPv4
+	// destination on an AF_INET6 socket with EINVAL. The error was discarded, so
+	// the caller saw only "connection timeout. server didn't respond" and the
+	// server logged nothing at all -- HandleConnect was never reached.
+	//
+	// Passes on Linux before and after; this is the platform-independent
+	// assertion that catches it where it happens.
+	ln, err := Listen("srt", ":6004", DefaultConfig())
+	require.NoError(t, err)
+	defer ln.Close()
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		req, err := ln.Accept2()
+		if err != nil {
+			return
+		}
+		conn, err := req.Accept()
+		if err != nil {
+			return
+		}
+		conn.Close()
+	}()
+
+	clientConn, err := Dial("srt", "127.0.0.1:6004", DefaultConfig())
+	require.NoError(t, err)
+	clientConn.Close()
+
+	<-serverDone
+}

--- a/packet_conn.go
+++ b/packet_conn.go
@@ -63,20 +63,31 @@ func (c *packetConn) readFromTo(buffer []byte) (int, net.Addr, net.IP, error) {
 	}
 }
 
-func (c *packetConn) writeToFrom(buffer []byte, remoteAddr net.Addr, localAddr net.Addr) {
+// writeToFrom sends buffer to remoteAddr, preferring to pin the source address
+// to localAddr so a multi-homed host answers from the address the peer used.
+//
+// Pinning is best-effort. On some platforms the ancillary-data send is rejected
+// for a destination whose family differs from the socket's -- notably an IPv4
+// destination on a dual-stack AF_INET6 socket on Darwin, where sendmsg returns
+// EINVAL. When that happens the packet is sent unpinned rather than dropped: an
+// unpinned reply reaches the peer on any single-homed host, whereas a dropped
+// one strands the handshake with no error anywhere.
+func (c *packetConn) writeToFrom(buffer []byte, remoteAddr net.Addr, localAddr net.Addr) error {
 	if localAddrUDP, ok := localAddr.(*net.UDPAddr); ok && localAddrUDP != nil {
 		if _, ok := remoteAddr.(*net.UDPAddr); ok {
 			// For IPv4 destinations use pc4 even on dual-stack sockets
 			if ip4 := localAddrUDP.IP.To4(); ip4 != nil && c.pc4 != nil {
-				c.pc4.WriteTo(buffer, &ipv4.ControlMessage{Src: ip4}, remoteAddr)
-				return
-			}
-			if c.pc6 != nil {
-				c.pc6.WriteTo(buffer, &ipv6.ControlMessage{Src: localAddrUDP.IP}, remoteAddr)
-				return
+				if _, err := c.pc4.WriteTo(buffer, &ipv4.ControlMessage{Src: ip4}, remoteAddr); err == nil {
+					return nil
+				}
+			} else if c.pc6 != nil {
+				if _, err := c.pc6.WriteTo(buffer, &ipv6.ControlMessage{Src: localAddrUDP.IP}, remoteAddr); err == nil {
+					return nil
+				}
 			}
 		}
 	}
 
-	c.WriteTo(buffer, remoteAddr)
+	_, err := c.WriteTo(buffer, remoteAddr)
+	return err
 }


### PR DESCRIPTION
Fixes #148.

## The bug

A dual-stack wildcard listener (`":port"`) never answers an IPv4 caller on Darwin. The caller's datagrams arrive, but the handshake never completes and **nothing is logged on either side** — `HandleConnect` is never reached, so an application cannot distinguish this from "no packets arrived". The caller sees only `connection timeout. server didn't respond`.

`writeToFrom` pins the reply's source address with an ancillary control message. For an IPv4 destination on an `AF_INET6` socket, `sendmsg` rejects that with `EINVAL` on Darwin; Linux tolerates it. The result was discarded, so nothing observed the failure.

## Measured, not inferred

On macOS, one dual-stack `[::]` socket writing to an IPv4 peer:

| path | result |
|---|---|
| `pc4.WriteTo` + `ipv4.ControlMessage{Src}` — current code | `sendmsg: invalid argument` |
| `pc4.WriteTo`, no control message | `sendmsg: invalid argument` |
| `pc6.WriteTo` + `ipv6.ControlMessage{Src}` | `sendmsg: invalid argument` |
| `pc6.WriteTo`, no control message | `sendmsg: invalid argument` |
| `pc6.WriteTo` → 16-byte v4-mapped destination | `sendmsg: invalid argument` |
| **plain `PacketConn.WriteTo`** | **ok** |

So no control-message variation, address form, or `PacketConn` family avoids it — the `x/net` sendmsg path simply cannot send from an `AF_INET6` socket to an IPv4 destination on Darwin. Only Go's own `WriteTo` can.

## The change

Two small edits.

**`writeToFrom` already ends in an unpinned `c.WriteTo`** — but the pinned branches `return` unconditionally, so that fallback is unreachable precisely when a pinned write fails. It now falls through to it. On Linux and on `AF_INET` sockets the pinned write still succeeds and the fallback never runs, so **pinning is unchanged wherever it works**.

**The single call site now logs** through the listener's existing `"packet:send:error"` channel when even the fallback fails, instead of discarding the error.

### The trade, stated plainly

An unpinned reply is a degradation, not a cure. I kept the pinned path first for that reason. `TestListenMultipleIPs` documents why pinning matters — a connected client discards a reply from an unexpected local address — and that behaviour is untouched on every platform where the pinned write succeeds.

Where it cannot succeed, the choice is between a packet that may be discarded by a multi-homed caller and a packet that is definitely never sent. The former reaches the peer on any single-homed host (the reported case); the latter strands the handshake with nothing logged anywhere. If you would rather it fail loudly there instead, say so and I will invert it.

## Test

`TestListenDualStackWildcardAcceptsIPv4`. The assertion is platform-independent — it passes on Linux before and after — and on Darwin it fails without this change with the caller's own `connection timeout. server didn't respond`. Verified by reverting only the two source files and keeping the test.

## Unrelated pre-existing failure

`TestListenMultipleIPs` is red on a stock macOS host **before and after** this commit, for an environmental reason: it dials `127.0.0.2`, which Linux provides across `127/8` but macOS does not configure on `lo0` without an explicit alias (`sudo ifconfig lo0 alias 127.0.0.2`). Not touched by this change.

`gofmt`, `go vet` and the rest of the suite are clean.
