### PR TITLE
Add srt.DialWithContext

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -73,6 +73,24 @@ type connResponse struct {
 //
 // In case of an error the returned Conn is nil and the error is non-nil.
 func Dial(network, address string, config Config) (Conn, error) {
+	return DialWithContext(context.Background(), network, address, config)
+}
+
+// DialWithContext connects to the address using the SRT protocol with the given config
+// and returns a Conn interface.
+//
+// The address is of the form "host:port".
+//
+// Example:
+//
+//	DialWithContext(context.Background(), "srt", "127.0.0.1:3000", DefaultConfig())
+//
+// In case of an error the returned Conn is nil and the error is non-nil.
+func DialWithContext(ctx context.Context, network, address string, config Config) (Conn, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context must not be nil")
+	}
+
 	if network != "srt" {
 		return nil, fmt.Errorf("the network must be 'srt'")
 	}
@@ -93,7 +111,7 @@ func Dial(network, address string, config Config) (Conn, error) {
 		Control: DialControl(config),
 	}
 
-	conn, err := netdialer.Dial("udp", address)
+	conn, err := netdialer.DialContext(ctx, "udp", address)
 	if err != nil {
 		return nil, fmt.Errorf("failed dialing: %w", err)
 	}
@@ -110,7 +128,7 @@ func Dial(network, address string, config Config) (Conn, error) {
 	dl.remoteAddr = pc.RemoteAddr()
 
 	dl.conn = nil
-	dl.connChan = make(chan connResponse)
+	dl.connChan = make(chan connResponse, 1)
 
 	dl.rcvQueue = make(chan packet.Packet, 2048)
 
@@ -180,28 +198,41 @@ func Dial(network, address string, config Config) (Conn, error) {
 
 	dl.log("dial", func() string { return "waiting for response" })
 
-	timer := time.AfterFunc(dl.config.ConnectionTimeout, func() {
-		dl.connChan <- connResponse{
-			conn: nil,
-			err:  fmt.Errorf("connection timeout. server didn't respond"),
-		}
-	})
+	timer := time.NewTimer(dl.config.ConnectionTimeout)
+	defer timer.Stop()
 
 	// Wait for handshake to conclude
-	response := <-dl.connChan
-	if response.err != nil {
-		timer.Stop()
+	select {
+	case response := <-dl.connChan:
+		if err := ctx.Err(); err != nil {
+			dl.Close()
+			return nil, err
+		}
+
+		if response.err != nil {
+			dl.Close()
+			return nil, response.err
+		}
+
+		dl.connLock.Lock()
+		dl.conn = response.conn
+		dl.connLock.Unlock()
+
+		return dl, nil
+
+	case <-ctx.Done():
 		dl.Close()
-		return nil, response.err
+		return nil, ctx.Err()
+
+	case <-timer.C:
+		if err := ctx.Err(); err != nil {
+			dl.Close()
+			return nil, err
+		}
+
+		dl.Close()
+		return nil, fmt.Errorf("connection timeout. server didn't respond")
 	}
-
-	timer.Stop()
-
-	dl.connLock.Lock()
-	dl.conn = response.conn
-	dl.connLock.Unlock()
-
-	return dl, nil
 }
 
 func (dl *dialer) checkConnection() error {

--- a/dial_test.go
+++ b/dial_test.go
@@ -2,6 +2,7 @@ package srt
 
 import (
 	"bytes"
+	"context"
 	"net"
 	"sync"
 	"testing"
@@ -75,6 +76,45 @@ func TestDialOK(t *testing.T) {
 	require.NoError(t, err)
 
 	ln.Close()
+}
+
+func TestDialWithContextCancel(t *testing.T) {
+	ln, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	inductionSeen := make(chan struct{})
+	go func() {
+		buf := make([]byte, MAX_MSS_SIZE)
+		_, _, err := ln.ReadFrom(buf)
+		if err == nil {
+			close(inductionSeen)
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := DialWithContext(ctx, "srt", ln.LocalAddr().String(), DefaultConfig())
+		result <- err
+	}()
+
+	select {
+	case <-inductionSeen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for induction packet")
+	}
+
+	cancel()
+
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for canceled dial")
+	}
 }
 
 func TestDialV4(t *testing.T) {


### PR DESCRIPTION
This allows to immediately interrupt the dialing without waiting for a response or a timeout. This is particularly useful to allow fast and clean shutdowns in any moment.