### PR TITLE
Suppress periodic ACKs that carry no new information

### DIFF
--- a/ack_suppression_test.go
+++ b/ack_suppression_test.go
@@ -1,0 +1,84 @@
+package srt
+
+import (
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLowRateACKOverhead measures the control traffic a slow live stream pays
+// for. A 1 fps camera at 25 kbit/s puts ~2.4 packets per second on the wire;
+// the periodic ACK runs on a 10 ms timer, so without suppression the sender
+// receives ~100 ACKs per second regardless — and owes an ACKACK for each.
+func TestLowRateACKOverhead(t *testing.T) {
+	const (
+		addr     = "127.0.0.1:6111"
+		interval = 400 * time.Millisecond // 2.5 packets/s, as at 1 fps / 25 kbit/s
+		packets  = 10                     // 4 s of stream
+	)
+
+	server := Server{
+		Addr: addr,
+		HandleConnect: func(req ConnRequest) ConnType {
+			if req.StreamId() == "publish" {
+				return PUBLISH
+			}
+			return REJECT
+		},
+		HandlePublish: func(conn Conn) {
+			buf := make([]byte, 1316)
+			for {
+				if _, err := conn.Read(buf); err != nil {
+					break
+				}
+			}
+			conn.Close()
+		},
+	}
+
+	require.NoError(t, server.Listen())
+	defer server.Shutdown()
+
+	go func() {
+		if err := server.Serve(); err != ErrServerClosed {
+			require.NoError(t, err)
+		}
+	}()
+
+	config := DefaultConfig()
+	config.StreamId = "publish"
+
+	conn, err := Dial("srt", addr, config)
+	require.NoError(t, err)
+
+	payload := make([]byte, 1316)
+	start := time.Now()
+	for i := 0; i < packets; i++ {
+		_, err := conn.Write(payload)
+		require.True(t, err == nil || err == io.EOF)
+		time.Sleep(interval)
+	}
+	elapsed := time.Since(start).Seconds()
+
+	stats := &Statistics{}
+	conn.Stats(stats)
+	conn.Close()
+
+	data := stats.Accumulated.PktSent
+	acks := stats.Accumulated.PktRecvACK
+	// 72 B per full ACK inbound, and the peer answers each with a 44 B ACKACK
+	// outbound; IPv4 + UDP counted in both.
+	fmt.Printf("\n%d data pkt (%.1f/s) | %d ack in (%.1f/s) "+
+		"| control %.1f kbit/s down, %.1f kbit/s up\n",
+		data, float64(data)/elapsed,
+		acks, float64(acks)/elapsed,
+		float64(acks)*72*8/1000/elapsed, float64(acks)*44*8/1000/elapsed)
+
+	// One ACK per data packet plus a handshake handful is healthy; the 10 ms
+	// timer unsuppressed would put this in the hundreds.
+	require.Less(t, acks, uint64(4*packets),
+		"periodic ACKs are not being suppressed on an idle link")
+}

--- a/connection.go
+++ b/connection.go
@@ -137,6 +137,14 @@ type connStats struct {
 // Check if we implement the net.Conn interface
 var _ net.Conn = &srtConn{}
 
+// ackRecord is a full ACK awaiting its ACKACK: when it was sent, for the RTT
+// estimate, and what it acknowledged, so that a repeat of it can be recognised
+// once the peer confirms it.
+type ackRecord struct {
+	timestamp time.Time
+	seq       circular.Number
+}
+
 type srtConn struct {
 	version  uint32
 	isCaller bool // Only relevant if version == 4
@@ -165,8 +173,16 @@ type srtConn struct {
 	rtt rtt // microseconds
 
 	ackLock       sync.RWMutex
-	ackNumbers    map[uint32]time.Time
+	ackNumbers    map[uint32]ackRecord
 	nextACKNumber circular.Number
+
+	// Bookkeeping for suppressing periodic ACKs that carry no news. See
+	// sendACK.
+	lastSentACK     circular.Number
+	lastSentACKTime time.Time
+	haveSentACK     bool
+	lastACKedACK    circular.Number
+	haveACKedACK    bool
 
 	initialPacketSequenceNumber circular.Number
 
@@ -268,7 +284,7 @@ func newSRTConn(config srtConnConfig) *srtConn {
 	}
 
 	c.nextACKNumber = circular.New(1, packet.MAX_TIMESTAMP)
-	c.ackNumbers = make(map[uint32]time.Time)
+	c.ackNumbers = make(map[uint32]ackRecord)
 
 	c.kmPreAnnounceCountdown = c.config.KMRefreshRate - c.config.KMPreAnnounce
 	c.kmRefreshCountdown = c.config.KMRefreshRate
@@ -839,9 +855,17 @@ func (c *srtConn) handleACKACK(p packet.Packet) {
 	c.log("control:recv:ACKACK:dump", func() string { return p.Dump() })
 
 	// p.typeSpecific is the ACKNumber
-	if ts, ok := c.ackNumbers[p.Header().TypeSpecific]; ok {
+	if ack, ok := c.ackNumbers[p.Header().TypeSpecific]; ok {
 		// 4.10.  Round-Trip Time Estimation
-		c.recalculateRTT(time.Since(ts))
+		c.recalculateRTT(time.Since(ack.timestamp))
+
+		// Remember what the peer has confirmed, so that sendACK can drop a
+		// periodic ACK that would repeat it.
+		if !c.haveACKedACK || ack.seq.Gt(c.lastACKedACK) {
+			c.lastACKedACK = ack.seq
+			c.haveACKedACK = true
+		}
+
 		delete(c.ackNumbers, p.Header().TypeSpecific)
 	} else {
 		c.log("control:recv:ACKACK:error", func() string { return fmt.Sprintf("got unknown ACKACK (%d)", p.Header().TypeSpecific) })
@@ -1212,8 +1236,17 @@ func (c *srtConn) sendNAK(list []circular.Number) {
 	c.pop(p)
 }
 
-// sendACK sends an ACK to the peer with the given sequence number.
+// sendACK sends an ACK to the peer with the given sequence number. A full ACK
+// that would only repeat what the peer has already confirmed is dropped, see
+// dropRepeatedACK.
 func (c *srtConn) sendACK(seq circular.Number, lite bool) {
+	c.ackLock.Lock()
+	defer c.ackLock.Unlock()
+
+	if !lite && c.dropRepeatedACK(seq) {
+		return
+	}
+
 	p := packet.NewPacket(c.remoteAddr)
 
 	p.Header().IsControlPacket = true
@@ -1224,9 +1257,6 @@ func (c *srtConn) sendACK(seq circular.Number, lite bool) {
 	cif := packet.CIFACK{
 		LastACKPacketSequenceNumber: seq,
 	}
-
-	c.ackLock.Lock()
-	defer c.ackLock.Unlock()
 
 	if lite {
 		cif.IsLite = true
@@ -1244,11 +1274,18 @@ func (c *srtConn) sendACK(seq circular.Number, lite bool) {
 
 		p.Header().TypeSpecific = c.nextACKNumber.Val()
 
-		c.ackNumbers[p.Header().TypeSpecific] = time.Now()
+		c.ackNumbers[p.Header().TypeSpecific] = ackRecord{
+			timestamp: time.Now(),
+			seq:       seq,
+		}
 		c.nextACKNumber = c.nextACKNumber.Inc()
 		if c.nextACKNumber.Val() == 0 {
 			c.nextACKNumber = c.nextACKNumber.Inc()
 		}
+
+		c.lastSentACK = seq
+		c.lastSentACKTime = time.Now()
+		c.haveSentACK = true
 	}
 
 	p.MarshalCIF(&cif)
@@ -1261,6 +1298,38 @@ func (c *srtConn) sendACK(seq circular.Number, lite bool) {
 	c.statisticsLock.Unlock()
 
 	c.pop(p)
+}
+
+// dropRepeatedACK reports whether a full ACK for seq would tell the peer only
+// what it already knows, in which case it is not worth a packet.
+//
+// The periodic ACK is paced by a 10 ms timer rather than by traffic, so a
+// connection carrying a couple of packets per second still produces ~100 ACKs
+// per second. Each is 72 bytes on the wire once IPv4 and UDP are counted, and
+// each obliges the sender to answer with a 44 byte ACKACK. On a low bitrate
+// live link — a 1 fps camera on a cellular or satellite uplink, say — that
+// exchange costs several times what the media does, in both directions.
+//
+// libsrt suppresses the repeats: CUDT::sendCtrlAck() returns early when the
+// sequence number has not advanced since the last ACKACK, and lets the
+// remaining repeats through no more than once per RTT + 4 RTTVar. This is the
+// same rule. Anything that acknowledges new data is always sent.
+//
+// The caller must hold ackLock.
+func (c *srtConn) dropRepeatedACK(seq circular.Number) bool {
+	if !c.haveSentACK || !seq.Equals(c.lastSentACK) {
+		return false // there is something new to acknowledge
+	}
+
+	if c.haveACKedACK && seq.Equals(c.lastACKedACK) {
+		return true // the peer has already confirmed exactly this
+	}
+
+	// Unconfirmed: either the ACK or its ACKACK may have been lost, so keep
+	// repeating — but at the RTT, not at the 10 ms tick.
+	repeatAfter := time.Duration(c.rtt.RTT()+4*c.rtt.RTTVar()) * time.Microsecond
+
+	return time.Since(c.lastSentACKTime) < repeatAfter
 }
 
 // sendACKACK sends an ACKACK to the peer with the given ACK sequence.


### PR DESCRIPTION
The periodic ACK is paced by a 10 ms timer rather than by traffic, so a connection carrying a couple of packets per second still produces about 100 ACKs per second. Each is 72 bytes on the wire once IPv4 and UDP are counted, and each obliges the sender to answer with a 44 byte ACKACK. On a low bitrate live link, such as a 1-5 fps camera on a cellular or satellite uplink, that exchange costs several times what the media does, in both directions.

A full ACK whose sequence number has not advanced since the last ACKACK is now dropped, and an unconfirmed repeat is sent no more often than once per RTT + 4 RTTVar. This is the rule libsrt applies in CUDT::sendCtrlAck(). Anything that acknowledges new data is always sent, and lite ACKs are untouched.

To know what the peer has confirmed, ackNumbers now stores an ackRecord holding both the send time and the acknowledged sequence number, so handleACKACK can record the highest sequence the peer has confirmed. sendACK takes ackLock for the whole call, since the suppression decision reads the same state the send updates.

Add TestLowRateACKOverhead, which drives 2.5 packets per second over a loopback connection and asserts the ACK count stays proportional to the data rate.